### PR TITLE
security: pin axios to exact lockfile version 1.7.9 (supply chain fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@monaco-editor/react": "^4.6.0",
     "@octokit/rest": "^20.0.2",
     "autoprefixer": "^10.4.17",
-    "axios": "^1.6.7",
+    "axios": "1.7.9",
     "classnames": "^2.5.1",
     "codeowners-utils": "^1.0.2",
     "next": "^14.1.0",


### PR DESCRIPTION
## Summary

Pins \`axios\` to its exact currently-installed version (\`1.7.9\`) to prevent silent upgrades to the malicious \`axios@1.14.1\` release, which pulls in \`plain-crypto-js@4.2.1\` (a supply chain dropper).

- **Attack vector:** \`^1.6.7\` allows \`npm install\` on a fresh machine to resolve to \`1.14.1\`
- **This change:** \`^1.6.7\` → \`1.7.9\` (exact version resolved in \`pnpm-lock.yaml\`)

No functional change — installed version is identical to what's already in \`pnpm-lock.yaml\`.

## Suggested reviewer
@wandbjake (Jake Pusateri)

🤖 Generated with [Claude Code](https://claude.com/claude-code)